### PR TITLE
Favorite is removed from page when deleted #19

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,6 +121,7 @@ function removeFavorite(event) {
     .catch(error => {
       console.error({ error })
     });
+    event.target.parentElement.remove();
   };
 };
 


### PR DESCRIPTION
### User Story #19: Favorite is removed from page when deleted
Closes #19 

#### What does this PR do?
- Removes the appropriate favorite list element from the Favorites List when a user clicks the Remove button

